### PR TITLE
Prevented duplicated parallel HTTP calls

### DIFF
--- a/src/app/interceptors/cache.interceptor.ts
+++ b/src/app/interceptors/cache.interceptor.ts
@@ -1,12 +1,14 @@
 import { Injectable } from '@angular/core';
 import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor, HttpResponse } from '@angular/common/http';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { CacheService } from '../services/cache.service';
-import { tap } from 'rxjs/operators';
+import { filter, first, map, shareReplay } from 'rxjs/operators';
 
 @Injectable()
 export class CacheInterceptor implements HttpInterceptor {
   constructor(private readonly cacheService: CacheService) {}
+
+  public readonly store: Record<string, Observable<HttpEvent<any>>> = {};
 
   intercept(request: HttpRequest<unknown>, next: HttpHandler): Observable<HttpEvent<unknown>> {
     // Don't cache if it's not a GET request
@@ -26,20 +28,26 @@ export class CacheInterceptor implements HttpInterceptor {
     // Checked if there is cached data for this URI
     const cachedResponse = this.cacheService.getFromCache(request);
     if (cachedResponse) {
-      // In case of parallel requests to same URI,
-      // return the request already in progress
-      // otherwise return the last cached data
-      return cachedResponse instanceof Observable ? cachedResponse : of(cachedResponse.clone());
+      return cachedResponse;
     }
 
     // If the request of going through for first time
     // then let the request proceed and cache the response
-    return next.handle(request).pipe(
-      tap(event => {
-        if (event instanceof HttpResponse) {
-          this.cacheService.addToCache(request, event);
-        }
-      })
+    const response = next.handle(request).pipe(
+      filter(res => res instanceof HttpResponse),
+      // The default Observable behavior is creating a new stream for each subscription.
+      // With shareReplay we avoid the default behavior and instead we execute the stream only once,
+      // then the result of that stream will be replayed to each new subscriber.
+      shareReplay(1)
+    );
+    this.cacheService.addToCache(request, response);
+    return response.pipe(
+      // Ensures that when the first value is received, the observable will automatically unsubscribe
+      // and stop listening for any further emissions.
+      first(),
+      // Clones the response, to avoid that further modifications to the data will affect the data
+      // within the cache.
+      map(event => (event as HttpResponse<any>).clone())
     );
   }
 }

--- a/src/app/services/cache.service.ts
+++ b/src/app/services/cache.service.ts
@@ -1,8 +1,9 @@
-import { HttpRequest, HttpResponse } from '@angular/common/http';
+import { HttpEvent, HttpRequest } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
 
 interface Cache {
-  response: HttpResponse<any>;
+  response: Observable<HttpEvent<any>>;
   time: number;
 }
 
@@ -12,14 +13,14 @@ const MAX_CACHE_AGE = 5 * 60 * 1000; // 5 minuti
 export class CacheService {
   cacheMap = new Map<string, Cache>();
 
-  getFromCache(req: HttpRequest<any>): HttpResponse<any> | undefined {
+  getFromCache(req: HttpRequest<any>): Observable<HttpEvent<any>> | undefined {
     const cached = this.cacheMap.get(req.urlWithParams);
 
     if (!cached || Date.now() - cached.time > MAX_CACHE_AGE) return undefined;
     return cached.response;
   }
 
-  addToCache(req: HttpRequest<any>, response: HttpResponse<any>): void {
+  addToCache(req: HttpRequest<any>, response: Observable<HttpEvent<any>>): void {
     this.cacheMap.set(req.url, { response, time: Date.now() });
   }
 }


### PR DESCRIPTION
Salve,

notavo che l'app effettua svariate richieste identiche in parallelo agli endpoint index.json (es: https://nodc.ogs.it/erddap/info/E2M3A_TS/index.json).

Ho dato un'occhiata al meccanismo di caching implementato nei file `cache.interceptor.ts` e `cache.service.ts` e ho visto che il dato viene inserito nella cache solo quando la risposta HTTP è completata. Pertanto eventuali richieste identiche che partono in parallelo vengono comunque eseguite tutte.

Dovrebbe esser possibile gestire richieste che partono in parallelo inserendo nella cache degli oggetti di tipo `Observable` al posto degli oggetti `HttpResponse`.

Ho visto che l'attuale implementazione sembra esser presa da qua: https://stackoverflow.com/a/56590462

Per le modifiche proposte in questa PR invece ho preso spunto da qua: https://stackoverflow.com/q/63303537

Ulteriore nota: né l'implementazione attuale né quella proposta rimuovono gli oggetti inseriti nella cache.

# Checklist

- [ ] I have read the contribution guidelines.
- [ ] First PR targets the `master` branch (ignore for branch specific issues).
- [ ] All the build checks are green.
- [ ] New unit tests have been added covering the changes.
- [ ] Documentation has been updated (if change is visible to end users).
- [ ] Bug fixes and small new features are presented as a single commit.
- [ ] Each commit has a single objective.

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
